### PR TITLE
Chore: typescript 개발 환경 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "3000:3000"
     volumes:
       - ./:/usr/src/app
-      - /usr/src/app/node_modules # <-- try adding this!
+      - /usr/src/app/node_modules
     environment:
       - NODE_ENV=development
+      - WATCHPACK_POLLING=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,11 @@
         "react-dom": "18.2.0",
         "react-redux": "^8.0.5",
         "redux": "^4.2.1"
+      },
+      "devDependencies": {
+        "@types/node": "^18.15.2",
+        "@types/react": "^18.0.28",
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@babel/runtime": {
@@ -274,6 +279,12 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "18.15.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.2.tgz",
+      "integrity": "sha512-sDPHm2wfx2QhrMDK0pOt2J4KLJMAcerqWNvnED0itPRJWvI+bK+uNHzcH1dFsBlf7G3u8tqXmRF3wkvL9yUwMw==",
+      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -681,6 +692,19 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "WATCHPACK_POLLING=true next dev",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start"
   },
@@ -14,5 +14,10 @@
     "react-dom": "18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^18.15.2",
+    "@types/react": "^18.0.28",
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
기존 소스에서 TypeScript 소스를 추가하여 개발 할 수 있게 설정
1. 루트 폴더에 tsconfig.json 생성 : nextjs에서 해당 파일만 있으면 typeSrcipt 사용을 자동으로 설정함.
2. docker-compose up 실행후 docker cli에서 다음 install 실행. npm install --save-dev typescript @types/react @types/node
3. 자동완성 된 tsconfig.json에 baseUrl: '.' 옵션으로 import 시 기본 경로를 루트로 지정함.
4. docker-compose.yml 파일에서 typescript 기반 hot reload 기능을 사용하기 위해 WATCHPACK_POLLING=true 옵션 추가 및 필요없는 주석 제거
5. package.json에서 WATCHPACK_POLLING=true 옵션 삭제.

##💁‍♂️설명
> 무엇에 대한 PR인지 설명해주세요.

TypeScript 개발 환경 추가입니다.
