### PR TITLE
create API - Google Login/UserCreate & 충돌 수정

### DIFF
--- a/components/templetes/login/google.tsx
+++ b/components/templetes/login/google.tsx
@@ -1,6 +1,7 @@
 import { User } from "@/models/User";
 import { useAppDispatch, useAppSelector } from "@/redux";
 import { closeDialog } from "@/redux/slices/globalSlice";
+import { createUser, fetchUser } from "@/redux/slices/userSlice";
 import { GoogleLogin, GoogleLoginProps } from "@react-oauth/google";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import jwt_decode from "jwt-decode";
@@ -12,10 +13,10 @@ const GoogleLoginButton = () => {
     <GoogleOAuthProvider clientId="1020336237076-038a3b00nth32pp49266f31sm4a5qfr6.apps.googleusercontent.com">
       <GoogleLogin
         onSuccess={(credentialResponse) => {
-          console.log(credentialResponse);
+          console.log("In credentialResponse !! :: ", credentialResponse);
           if (credentialResponse.credential) {
             const decoded: any = jwt_decode(credentialResponse.credential);
-            console.log(decoded);
+            console.log("decoded !! :: ", decoded);
             dispatch({
               type: "user/setUser",
               payload: {
@@ -25,6 +26,12 @@ const GoogleLoginButton = () => {
                 picture: decoded.picture,
               },
             });
+            dispatch(createUser(decoded)).then((e) => {
+              console.log("In disPatch Then", e);
+            });
+            // dispatch(fetchUser()).then((e) => {
+            //   console.log("In disPatch Then", e);
+            // });
             dispatch(closeDialog());
           }
 

--- a/models/Fetch.ts
+++ b/models/Fetch.ts
@@ -1,0 +1,5 @@
+// export UserAPI interface for UserSlice.ts
+export interface Fetch {
+    loading: false,
+    error: undefined,
+}

--- a/redux/slices/userSlice.ts
+++ b/redux/slices/userSlice.ts
@@ -1,38 +1,112 @@
 // redux-toolkit slice for user
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { User } from '@/models/User';
+import { enqueueSnackbar } from 'notistack';
+import { Fetch } from '@/models/fetch';
 
-const initialState: User = {
+// make Post thunk
+export const fetchUser = createAsyncThunk(
+    'user/getList'
+    , async () => {
+        // make 2 seconds delay
+        // await new Promise((resolve) => setTimeout(resolve));
+        const response = await fetch('http://localhost:8080/members');
+        console.log("In fetchUser!! :: response :: ", response);
+        const data = await response.json();
+        console.log("In fetchUser!! :: data :: ", data);
+        return data as User;
+    }
+);
+
+// make Post thunk
+export const createUser = createAsyncThunk(
+    'user/create'
+    , async (decoded:User, thunkAPI) => {
+        console.log("In createUser thunk :", decoded);
+        // make 2 seconds delay
+        // await new Promise((resolve) => setTimeout(resolve));
+        var option = {
+            method: 'POST', // *GET, POST, PUT, DELETE 등
+            mode: 'cors', // no-cors, *cors, same-origin
+            cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+            credentials: 'same-origin', // include, *same-origin, omit
+            headers: {
+                'Content-Type': 'application/json', // 'Content-Type': 'application/x-www-form-urlencoded',
+                },
+            redirect: 'follow', // manual, *follow, error
+            referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+            body: JSON.stringify({
+                'email':decoded.email
+                ,'username':decoded.name
+            }) // body의 데이터 유형은 반드시 "Content-Type" 헤더와 일치해야 함
+        };
+
+        console.log("request body :: ", option.body);
+        const response = await fetch('http://localhost:8080/api/members', option);
+        console.log("In fetchUser!! :: response :: ", response);
+        const data = await response.json();
+        console.log("In fetchUser!! :: data :: ", data);
+        return data as User;
+    }
+);
+
+type UserFetchMix = User & Fetch; // type Mix
+
+const initialState: UserFetchMix = {
     id: '',
     name: '',
     email: '',
     avatar: '',
     token: '',
-    picture: undefined
+    loading:false,
+    error:undefined
 };
 
 const userSlice = createSlice({
     name: 'user',
     initialState,
     reducers: {
-        setUser: (state, action: PayloadAction<User>) => {
+        // setUser: (state, action: PayloadAction<User>) => {
+        //     state.id = action.payload.id;
+        //     state.name = action.payload.name;
+        //     state.email = action.payload.email;
+        //     state.avatar = action.payload.avatar;
+        //     state.token = action.payload.token;
+        // },
+        // clearUser: (state) => {
+        //     state.id = '';
+        //     state.name = '';
+        //     state.email = '';
+        //     state.avatar = '';
+        //     state.token = '';
+        // },
+    },
+    extraReducers: (builder) => {
+        builder.addCase(fetchUser.fulfilled, (state, action) => {
+            console.log("extraReducers fulfilled :: ", state, action);
             state.id = action.payload.id;
             state.name = action.payload.name;
             state.email = action.payload.email;
             state.avatar = action.payload.avatar;
             state.token = action.payload.token;
-        },
-        clearUser: (state) => {
-            state.id = '';
-            state.name = '';
-            state.email = '';
-            state.avatar = '';
-            state.token = '';
-        },
-    }
+            state.loading = false;
+            state.error = undefined;
+            // enqueueSnackbar('성공.', { variant: 'success' });
+        });
+        builder.addCase(fetchUser.rejected, (state, action) => {
+            console.log('extraReducers rejected :: ');
+            // state.loading = false;
+            // state.error = action.error.message;
+            // enqueueSnackbar(state.error, { variant: 'error' });
+        });
+        builder.addCase(fetchUser.pending, (state) => {
+            console.log('extraReducers pending :: ');
+            // state.loading = true;
+        });
+    },
 });
 
 //export selectUser function
 export const selectUser = (state: any) => state.user;
-export const { setUser, clearUser } = userSlice.actions;
+// export const { setUser, clearUser } = userSlice.actions;
 export default userSlice.reducer;


### PR DESCRIPTION
##💁‍♂️설명
Google Login시 로컬 백엔드 서버로 create통신을 하는 커밋입니다.

##🔗연결된 이슈
https://co-up.atlassian.net/jira/software/projects/CU/boards/1?selectedIssue=CU-75

##✅체크리스트
components/templetes/login/google.tsx (호출부분)
 - dispatch(createUser(decoded))
redux/slices/userSlice.ts (이벤트 선언 부분 (thunk방식의 이벤트)) 
 - export const createUser = createAsyncThunk()
models/Fetch.ts (모델 생성)
 - 통신 모델 생성
- models/User.ts 에 대한 충돌 내용을 수정

##🚨주의사항
현재 setUser, clearUser의 리듀서, 엑스트라리듀서 부분을 주석 처리 해놓았는데, reducer부분에 대한 이해가 없어서 이렇게 했지만, reducer와 extraReducer의 동작 원리를 이해하면 추가해야함
